### PR TITLE
feat: Upgrade to Zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache/
 zig-out/
+.zig-cache

--- a/build.zig
+++ b/build.zig
@@ -11,22 +11,26 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(lib);
 
-    const cflags: []const []const u8 = switch (target.toTarget().abi) {
+    const cflags: []const []const u8 = switch (target.result.abi) {
         .msvc => &.{"-DM_PI=3.1415826535"},
         else => &.{},
     };
-    lib.addCSourceFiles(&.{
-        "src/denoise.c",
-        "src/rnn.c",
-        "src/rnn_data.c",
-        "src/rnn_reader.c",
-        "src/pitch.c",
-        "src/kiss_fft.c",
-        "src/celt_lpc.c",
-    }, cflags);
-    lib.addIncludePath(.{ .path = "include" });
+    lib.addCSourceFiles(.{
+        .files = &.{
+            "src/denoise.c",
+            "src/rnn.c",
+            "src/rnn_data.c",
+            "src/rnn_reader.c",
+            "src/pitch.c",
+            "src/kiss_fft.c",
+            "src/celt_lpc.c",
+        },
+        .flags = cflags,
+    });
+
+    lib.addIncludePath(.{ .cwd_relative = "include" });
     lib.linkLibC();
-    lib.installHeader("include/rnnoise.h", "rnnoise.h");
+    lib.installHeader(.{ .cwd_relative = "include/rnnoise.h" }, "rnnoise.h");
 
     {
         const exe = b.addExecutable(.{
@@ -34,9 +38,9 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
         });
-        exe.addCSourceFiles(&.{
+        exe.addCSourceFiles(.{ .files = &.{
             "examples/rnnoise_demo.c",
-        }, &.{});
+        } });
         exe.linkLibrary(lib);
         b.installArtifact(exe);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = "rnnoise",
     .version = "0.0.0",
 
-    .minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.13.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
Upgrades the project to use Zig 0.13.0, adapting the build script to accommodate breaking changes introduced in the newer Zig version. The update involves modifying the handling of C source file additions, include paths, and target ABI access to align with the updated Zig API.