### PR TITLE
build.zig: update for 0.16.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,8 +51,6 @@ pub fn build(b: *std.Build) void {
         .root_source_file = upstream.path("include/rnnoise.h"),
         .target = target,
         .optimize = optimize,
-        .link_libc = true,
-        .use_clang = true,
     });
 
     _ = headers.addModule("headers");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .rnnoise,
     .version = "0.0.1",
     .fingerprint = 0xefee11620c5ad3ec,
-    .minimum_zig_version = "0.16.0-dev.2676+4e2cec265",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .upstream = .{
             .url = "git+https://github.com/xiph/rnnoise?ref=main#70f1d256acd4b34a572f999a05c87bf00b67730d",


### PR DESCRIPTION
use_clang was removed because it no longer does anything, and link_libc defaults to true.